### PR TITLE
Added support for declaring component variables using Configure::write('CakeS3')

### DIFF
--- a/Controller/Component/CakeS3Component.php
+++ b/Controller/Component/CakeS3Component.php
@@ -8,7 +8,7 @@ App::import('Lib', 'CakeS3.S3');
  *
  * @author Dave Baker
  * @copyright Dave Baker (Fully Baked) 2012
- * @see http://undesigned.org.za/2007/10/22/amazon-s3-phppublic - class for the S3 class included in the vendor dir
+ * @see https://github.com/fullybaked/CakeS3 - class for the S3 class included in the vendor dir
  */
 class CakeS3Component extends Component
 {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Or add the settings before invoking the Plugin in Config/bootstrap.php
 			's3Key' => 'YOUR_AMAZON_S3_KEY',
 			's3Secret' => 'YOUR_AMAZON_S3_SECRET_KEY',
 			'bucket' => 'BUCKET_NAME',
+			'endpoint' => 's3.amazonaws.com' // [optional] Only required if your endpoint is not s3.amazonaws.com
 			)
 	);
 	CakePlugin::load('CakeS3');


### PR DESCRIPTION
Added support for declaring component variables using Configure::write('CakeS3'), because I didn't want to hard-code settings in the Controller.
