### PR TITLE
Throw Exception when URL is badly formatted

### DIFF
--- a/Controller/Component/CakeS3Component.php
+++ b/Controller/Component/CakeS3Component.php
@@ -267,9 +267,13 @@ class CakeS3Component extends Component
      * @param string $url
      * @return string
      * @access public
+     * @throws Exception
      */
     public function relativePath($url)
     {
+        if(!filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new Exception("Badly formatted URL passed to relativePath");
+        }
         $remove = array(
             ($this->useSsl) ? 'https://' : 'http://',
             $this->endpoint . '/',


### PR DESCRIPTION
Ran into an issue where URL was badly formatted (data corruption) 

Have added this Exception throw after filter_var validation. 

This seems appropriate as we should already be catching S3 Exceptions